### PR TITLE
fixed models to not allowNull for userId and postId for comments mode…

### DIFF
--- a/dvlpr/migrations/20210920155454-create-post.js
+++ b/dvlpr/migrations/20210920155454-create-post.js
@@ -14,7 +14,8 @@ module.exports = {
         references: {
           model: 'users',
           key: 'id'
-        }
+        },
+        allowNull: false
       },
       postContent: {
         type: Sequelize.STRING,

--- a/dvlpr/migrations/20210920155844-create-comment.js
+++ b/dvlpr/migrations/20210920155844-create-comment.js
@@ -14,7 +14,8 @@ module.exports = {
         references: {
           model: 'users',
           key: 'id'
-        }
+        },
+        allowNull: false
       },
       postId: {
         type: Sequelize.INTEGER,
@@ -22,7 +23,8 @@ module.exports = {
         references: {
           model: 'posts',
           key: 'id'
-        }
+        },
+        allowNull: false
       },
       commentContent: {
         type: Sequelize.STRING,

--- a/dvlpr/models/comment.js
+++ b/dvlpr/models/comment.js
@@ -20,7 +20,8 @@ module.exports = (sequelize, DataTypes) => {
         references: {
           model: 'users',
           key: 'id'
-        }
+        },
+        allowNull: false
       },
       postId: {
         type: DataTypes.INTEGER,
@@ -28,7 +29,8 @@ module.exports = (sequelize, DataTypes) => {
         references: {
           model: 'posts',
           key: 'id'
-        }
+        },
+        allowNull: false
       },
       commentContent: {
         type: DataTypes.STRING,

--- a/dvlpr/models/post.js
+++ b/dvlpr/models/post.js
@@ -20,7 +20,8 @@ module.exports = (sequelize, DataTypes) => {
         references: {
           model: 'users',
           key: 'id'
-        }
+        },
+        allowNull: false
       },
       postContent: {
         type: DataTypes.STRING,


### PR DESCRIPTION
In comment model, when creating new comment it is allowing a userId and postId of null. Did undo migration and fixed models and migrations. Same for post model and migration to not all null. 