### PR TITLE
userName now shows with corresponding comment, added timestampe as well

### DIFF
--- a/dvlpr/client/src/components/Comments.js
+++ b/dvlpr/client/src/components/Comments.js
@@ -22,8 +22,9 @@ const Comments = (data) => {
         {comments.map((comment) => (
           <div>
             {/* <Comment /> */}
-            <li key={comment.Id}>{comment.userId}</li>
+            <li key={comment.Id}>{comment.commentsAndUsers.userName}</li>
             <li key={comment.Id}>{comment.commentContent}</li>
+            <li key={comment.Id}>{comment.createdAt}</li>
           </div>
         ))}
       </ul>

--- a/dvlpr/controllers/CommentController.js
+++ b/dvlpr/controllers/CommentController.js
@@ -6,7 +6,7 @@ const GetComments = async (req, res) => {
       include: {
         model: User,
         as: 'commentsAndUsers',
-        attributes: ['id', 'userName']
+        attributes: ['id', 'userName', 'createdAt']
       }
     })
 


### PR DESCRIPTION
When listing all comments, it will now show createdAt, userName, and commentContent. 